### PR TITLE
fix #49 ignore key release events

### DIFF
--- a/src/tui.rs
+++ b/src/tui.rs
@@ -1,6 +1,6 @@
 use crate::types::Event;
 use color_eyre::Result;
-use crossterm::event::{Event as CrosstermEvent, EventStream};
+use crossterm::event::{Event as CrosstermEvent, EventStream, KeyEventKind};
 use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
 use crossterm::terminal::{EnterAlternateScreen, LeaveAlternateScreen};
 use crossterm::{cursor, execute};
@@ -81,6 +81,9 @@ where
                     tx.send(Event::Mouse(mouse)).unwrap();
                 }
                 CrosstermEvent::Key(key) => {
+                    if key.kind == KeyEventKind::Release {
+                        return;
+                    }
                     tx.send(Event::Key(key)).unwrap();
                 }
                 _ => {


### PR DESCRIPTION
fixed an issue where key press and key release events were being registered, causing actions to be performed twice